### PR TITLE
fix(graphql): UUID/DateTime/Date/Time as first-class scalars (6.1.0)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 ---
-description: "Release-by-release changelog for pydantic-resolve, following semver — major for breaking changes, minor for new features, patch for bug fixes. Most recent: 6.0.0."
+description: "Release-by-release changelog for pydantic-resolve, following semver — major for breaking changes, minor for new features, patch for bug fixes. Most recent: 6.1.0."
 ---
 
 # Changelog
@@ -7,6 +7,15 @@ description: "Release-by-release changelog for pydantic-resolve, following semve
 - **Major (X.0.0)**: Major new features or breaking changes
 - **Minor (x.Y.0)**: New features, backward compatible
 - **Patch (x.y.Z)**: Bug fixes and minor improvements
+
+## 6.1
+
+### 6.1.0 (2026-8-2)
+
+- fix:
+  - **`UUID` / `DateTime` / `Date` / `Time` are now first-class GraphQL scalars** (port of nexusx #104 / #92 / #105): `uuid.UUID`, `datetime`, `date`, and `time` previously fell back to `String` everywhere — the scalar map only knew `int`/`str`/`float`/`bool`, and `map_scalar_type` used fragile substring matching. SDL rendered `id: UUID` as `id: String!`, introspection never advertised the scalars, and `@query` / `@mutation` params of these types (including `list[UUID]`, `list[datetime]`, `Optional[T]`) arrived as raw strings — crashing SQLAlchemy/SQLModel on `UUID` / `datetime` column binding. They now render as `UUID!` / `DateTime!` / `Date!` / `Time!` in SDL, are advertised as scalars in `__schema`, and are coerced to real Python objects on the input side. The introspection scalar list and `TypeRegistry._scalars` are now derived from the single `SCALAR_TYPES` registry so they can't drift.
+
+    **SDL surface change** (why this is a minor, not a patch): fields/args of these types change from `String` to `UUID` / `DateTime` / `Date` / `Time`. Transport is unchanged (still string-serialized ISO 8601 / UUID). SDL consumers (graphql-codegen, Apollo) will see new scalar names and should regenerate types. `Decimal` is unchanged (still `String`).
 
 ## 6.0
 

--- a/pydantic_resolve/graphql/executor.py
+++ b/pydantic_resolve/graphql/executor.py
@@ -13,8 +13,10 @@ import asyncio
 import inspect
 import logging
 import os
+from datetime import date, datetime, time
 from enum import Enum
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union, get_args, get_origin
+from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -28,6 +30,17 @@ from pydantic_resolve.graphql.utils import group_type_name
 from pydantic_resolve.graphql.response_builder import ResponseBuilder
 
 logger = logging.getLogger(__name__)
+
+
+# Scalar types whose GraphQL wire form is a string but which callers expect as
+# real Python objects (UUID/datetime/date/time). Ordered: datetime subclasses
+# date, so datetime must precede date.
+_COERCIBLE_SCALARS = (UUID, datetime, time, date)
+
+
+def _is_coercible_scalar(py_type: Any) -> bool:
+    """True if ``py_type`` is a temporal/UUID scalar we coerce from string."""
+    return any(safe_issubclass(py_type, t) for t in _COERCIBLE_SCALARS)
 
 
 class QueryExecutor:
@@ -494,6 +507,12 @@ class QueryExecutor:
                                         for item in value
                                     ]
                                 break
+                        # Handle temporal/UUID scalar params (incl list[T], Optional[T]).
+                        # GraphQL sends these as strings; coerce to the real Python
+                        # object so e.g. SQLAlchemy UUID/datetime columns don't crash.
+                        elif _is_coercible_scalar(core_type):
+                            converted_value = self._convert_scalar_value(value, param_type)
+                            break
 
                     if converted_value is not None:
                         converted[param_name] = converted_value
@@ -507,6 +526,48 @@ class QueryExecutor:
             return arguments
 
         return converted
+
+    def _convert_scalar_value(self, value: Any, target_type: Any) -> Any:
+        """Coerce a GraphQL wire value (string) to a temporal/UUID scalar.
+
+        Recurses into ``list[T]`` and unwraps ``Optional[T]`` / ``Union[T, None]``
+        so ``list[UUID]``, ``Optional[datetime]``, and ``list[Optional[date]]``
+        all convert element-wise. Non-string leaves are returned unchanged.
+        """
+        # Unwrap Optional[T] / Union[T, None] -> T
+        if get_origin(target_type) is Union:
+            non_none = [a for a in get_args(target_type) if a is not type(None)]
+            if len(non_none) == 1:
+                target_type = non_none[0]
+
+        if get_origin(target_type) is list:
+            (elem_type,) = get_args(target_type) or (None,)
+            if elem_type is None:
+                return value
+            return [self._convert_scalar_value(item, elem_type) for item in value]
+
+        return self._coerce_scalar(value, target_type)
+
+    @staticmethod
+    def _coerce_scalar(value: Any, py_type: Any) -> Any:
+        """Coerce a single string wire value to the target scalar, or return it."""
+        if not isinstance(value, str):
+            return value
+        try:
+            # datetime subclasses date -> check datetime first
+            if safe_issubclass(py_type, UUID):
+                return UUID(value)
+            if safe_issubclass(py_type, datetime):
+                # datetime.fromisoformat (pre-3.11) rejects trailing 'Z'
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if safe_issubclass(py_type, time):
+                return time.fromisoformat(value)
+            if safe_issubclass(py_type, date):
+                return date.fromisoformat(value)
+        except (ValueError, TypeError):
+            # Leave as-is; let the method body / validation surface the error.
+            return value
+        return value
 
     def _convert_to_model(self, data: dict, model_class: type) -> BaseModel:
         """

--- a/pydantic_resolve/graphql/schema/generators/introspection_generator.py
+++ b/pydantic_resolve/graphql/schema/generators/introspection_generator.py
@@ -164,7 +164,7 @@ class IntrospectionGenerator(SchemaGenerator):
         types = []
 
         # Add scalar types (convert TypeInfo to dict format)
-        for name in ["Int", "Float", "String", "Boolean", "ID"]:
+        for name in SCALAR_TYPES:
             scalar = SCALAR_TYPES[name]
             types.append({
                 "kind": scalar.kind,

--- a/pydantic_resolve/graphql/schema/type_registry.py
+++ b/pydantic_resolve/graphql/schema/type_registry.py
@@ -83,6 +83,26 @@ SCALAR_TYPES: dict[str, TypeInfo] = {
         kind="SCALAR",
         description="The `ID` scalar type represents a unique identifier."
     ),
+    "UUID": TypeInfo(
+        name="UUID",
+        kind="SCALAR",
+        description="The `UUID` scalar type represents a UUID, serialized as a string."
+    ),
+    "DateTime": TypeInfo(
+        name="DateTime",
+        kind="SCALAR",
+        description="The `DateTime` scalar type represents an ISO 8601 datetime, serialized as a string."
+    ),
+    "Date": TypeInfo(
+        name="Date",
+        kind="SCALAR",
+        description="The `Date` scalar type represents an ISO 8601 date, serialized as a string."
+    ),
+    "Time": TypeInfo(
+        name="Time",
+        kind="SCALAR",
+        description="The `Time` scalar type represents an ISO 8601 time, serialized as a string."
+    ),
 }
 
 
@@ -96,7 +116,7 @@ class TypeRegistry:
 
     def __init__(self):
         self._types: dict[str, TypeInfo] = {}
-        self._scalars: set = {'Int', 'Float', 'String', 'Boolean', 'ID'}
+        self._scalars: set = set(SCALAR_TYPES.keys())
 
         # Register standard scalars
         for name, type_info in SCALAR_TYPES.items():

--- a/pydantic_resolve/graphql/type_mapping.py
+++ b/pydantic_resolve/graphql/type_mapping.py
@@ -5,6 +5,8 @@ Provides centralized type conversion between Python and GraphQL types.
 """
 
 from enum import Enum
+from datetime import datetime, date, time
+from uuid import UUID
 from typing import get_origin, get_args, Union
 from pydantic_resolve.utils.class_util import safe_issubclass
 from pydantic_resolve.utils.types import get_core_types, _is_optional, _is_list
@@ -18,6 +20,16 @@ PYTHON_TO_GQL_TYPES = {
     float: 'Float',
     bool: 'Boolean',
 }
+
+# Temporal + UUID scalars, matched by subclass. Ordered: ``datetime`` is a
+# subclass of ``date``, so it must come first or a datetime field would wrongly
+# map to ``Date``. Transport stays string-serialized (ISO 8601 / UUID str).
+_SCALAR_SUBCLASS_MAP = (
+    (UUID, "UUID"),
+    (datetime, "DateTime"),
+    (time, "Time"),
+    (date, "Date"),
+)
 
 
 def is_enum_type(python_type: type) -> bool:
@@ -145,6 +157,11 @@ def map_scalar_type(python_type: type) -> str:
     if python_type in PYTHON_TO_GQL_TYPES:
         return PYTHON_TO_GQL_TYPES[python_type]
 
+    # Temporal + UUID scalars (subclass-matched; ordered datetime before date)
+    for py_cls, gql_name in _SCALAR_SUBCLASS_MAP:
+        if safe_issubclass(python_type, py_cls):
+            return gql_name
+
     # Check via string (handle type strings, etc.)
     type_str = str(python_type).lower()
     if "int" in type_str:
@@ -173,6 +190,10 @@ def get_graphql_type_description(gql_type: str) -> str:
         "String": "The `String` scalar type represents textual data.",
         "Boolean": "The `Boolean` scalar type represents `true` or `false`.",
         "ID": "The `ID` scalar type represents a unique identifier.",
+        "UUID": "The `UUID` scalar type represents a UUID, serialized as a string.",
+        "DateTime": "The `DateTime` scalar type represents an ISO 8601 datetime, serialized as a string.",
+        "Date": "The `Date` scalar type represents an ISO 8601 date, serialized as a string.",
+        "Time": "The `Time` scalar type represents an ISO 8601 time, serialized as a string.",
     }
     return descriptions.get(gql_type)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-resolve"
-version = "6.0.0"
+version = "6.1.0"
 description = "Entity-First Architecture framework for Python: define business entities, declare relationships, and let the framework assemble your data."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/graphql/test_datetime_support.py
+++ b/tests/graphql/test_datetime_support.py
@@ -2,7 +2,7 @@
 import json
 from datetime import datetime, date, time
 from decimal import Decimal
-from uuid import uuid4
+from uuid import UUID, uuid4
 from typing import List, Optional, Annotated
 
 import pytest
@@ -37,7 +37,7 @@ class DateTimeEntity(BaseModel, BaseEntity):
     birth_date: Optional[date] = None
     schedule_time: Optional[time] = None
     price: Optional[Decimal] = None
-    uuid_field: Optional[str] = None
+    uuid_field: Optional[UUID] = None
     # Custom UtcDatetime type
     utc_time: Optional[UtcDatetime] = None
 
@@ -51,7 +51,7 @@ class DateTimeEntity(BaseModel, BaseEntity):
                 birth_date=date(2024, 1, 1),
                 schedule_time=time(14, 30, 0),
                 price=Decimal("99.99"),
-                uuid_field=str(uuid4()),
+                uuid_field=uuid4(),
                 utc_time=datetime(2024, 1, 1, 12, 30, 45),
             ),
         ]
@@ -131,9 +131,80 @@ class TestDateTimeSDLGeneration:
         config_global_resolver(self.er_diagram)
 
     def test_datetime_field_in_schema(self):
-        """Test that datetime fields have correct type in schema."""
+        """Temporal/UUID fields render as real GraphQL scalars, not String."""
         schema_builder = SchemaBuilder(self.er_diagram)
         sdl = schema_builder.build_schema()
 
-        # DateTime should be mapped to String (GraphQL scalar)
-        assert "created_at: DateTime!" in sdl or "created_at: String!" in sdl
+        # Required scalar -> NonNull; Optional scalar -> nullable (no `!`).
+        assert "created_at: DateTime!" in sdl
+        assert "birth_date: Date" in sdl      # Optional[date] -> nullable Date
+        assert "schedule_time: Time" in sdl
+        assert "uuid_field: UUID" in sdl
+        # None of these should fall back to String.
+        assert "created_at: String" not in sdl
+        assert "uuid_field: String" not in sdl
+
+    def test_scalars_advertised_in_introspection(self):
+        """__schema must advertise UUID/DateTime/Date/Time as scalar types."""
+        handler = GraphQLHandler(self.er_diagram)
+        schema = handler.introspection._generator.generate()
+        scalar_names = {
+            t["name"] for t in schema["types"] if t.get("kind") == "SCALAR"
+        }
+        assert {"UUID", "DateTime", "Date", "Time"}.issubset(scalar_names)
+
+
+# Separate diagram so the arg-conversion entity doesn't widen the SDL tests above.
+ArgBase = base_entity()
+_ARG_RECEIVED: dict = {}
+
+
+class ArgEntity(BaseModel, ArgBase):
+    """Exercises scalar arg coercion (single, list[T], Optional[list[T]])."""
+    __relationships__ = []
+    id: int
+
+    @query
+    async def by_ids(cls, ids: List[UUID]) -> List["ArgEntity"]:
+        _ARG_RECEIVED["ids"] = [type(x).__name__ for x in ids]
+        return []
+
+    @query
+    async def by_whens(cls, whens: List[datetime]) -> List["ArgEntity"]:
+        _ARG_RECEIVED["whens"] = [type(x).__name__ for x in whens]
+        return []
+
+    @query
+    async def by_single(cls, u: UUID, d: date, t: time) -> List["ArgEntity"]:
+        _ARG_RECEIVED["single"] = (type(u).__name__, type(d).__name__, type(t).__name__)
+        return []
+
+
+class TestScalarArgConversion:
+    """Methods must receive real UUID/datetime/date/time objects, not strings."""
+
+    def setup_method(self):
+        self.er_diagram = ArgBase.get_diagram()
+        config_global_resolver(self.er_diagram)
+        self.handler = GraphQLHandler(self.er_diagram)
+
+    @pytest.mark.asyncio
+    async def test_list_uuid_arg(self):
+        await self.handler.execute(
+            '{ ArgEntity { by_ids(ids: ["550e8400-e29b-41d4-a716-446655440000"]) { id } } }'
+        )
+        assert _ARG_RECEIVED["ids"] == ["UUID"]
+
+    @pytest.mark.asyncio
+    async def test_list_datetime_arg(self):
+        await self.handler.execute(
+            '{ ArgEntity { by_whens(whens: ["2024-01-01T10:00:00"]) { id } } }'
+        )
+        assert _ARG_RECEIVED["whens"] == ["datetime"]
+
+    @pytest.mark.asyncio
+    async def test_single_scalar_args(self):
+        await self.handler.execute(
+            '{ ArgEntity { by_single(u: "550e8400-e29b-41d4-a716-446655440000", d: "2024-03-04", t: "11:22:33") { id } } }'
+        )
+        assert _ARG_RECEIVED["single"] == ("UUID", "date", "time")

--- a/uv.lock
+++ b/uv.lock
@@ -1560,7 +1560,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-resolve"
-version = "5.10.5"
+version = "6.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodataloader" },


### PR DESCRIPTION
Port of nexusx #104 / #92 / #105. `uuid.UUID`, `datetime`, `date`, `time` all fell back to `String` — the scalar map only knew `int/str/float/bool` and `map_scalar_type` used fragile substring matching.

## Root cause (verified on master)
- `id: UUID` → `id: String!`, `created_at: datetime` → `String!`, `d: date` → `String!`, `t: time` → `String!`
- Introspection advertised only `Int/Float/String/Boolean/ID` — `UUID/DateTime/Date/Time` missing, so GraphiQL couldn't discover them
- `list[UUID]` / `list[datetime]` / single `@query`/`@mutation` params arrived as raw `str` → crashes SQLAlchemy/SQLModel on UUID/datetime column binding

## Fix
- **`type_mapping.py`**: subclass-matched `UUID/datetime/time/date` (datetime ordered before date) → SDL + introspection field type-refs render `UUID!/DateTime!/Date!/Time!`
- **`type_registry.py`**: register the 4 scalars in `SCALAR_TYPES`; derive `TypeRegistry._scalars` from it (kills the two-list drift)
- **`introspection_generator.py`**: advertise every `SCALAR_TYPES` entry (was a hardcoded 5-name list)
- **`executor.py`**: `_convert_scalar_value` / `_coerce_scalar` coerce these args from string to the real object, recursing through `list[T]`, `Optional[T]`, `Optional[list[T]]`

## Verification
- New repros: `list[UUID]`→`[UUID]`, `list[datetime]`→`[datetime]`, single `UUID/date/time`→real objects, `Optional[list[UUID]]`→`[UUID]` ✅
- `tests/graphql/`: **252 passed** (was 248, +4). Tightened `test_datetime_support` (pinned scalar names, real `UUID` type, dropped the permissive `String` OR) + added `list[UUID]`/`list[datetime]`/single-scalar arg-conversion regressions + introspection-advertising check
- `tests/ + demo/`: **905 passed, 1 skipped**
- `ruff`: clean

## Not bugs (verified — not ported)
- Self-referential types → PR handles fine (no RecursionError, unlike nexusx #91)
- `has_more` off-by-one (nexusx #86) → PR doesn't compute it (user `page_loader` owns it)
- SDL `limit/offset` on paginated fields (#98) → PR already has it

## Version
6.1.0 (minor) — **SDL surface change**: fields/args of these types change `String` → `UUID`/`DateTime`/`Date`/`Time`. Transport unchanged. SDL consumers (codegen/Apollo) should regenerate. `Decimal` unchanged. Bumps `pyproject.toml` + `uv.lock` + changelog; publish via `v6.1.0` tag after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)